### PR TITLE
fix: reset education section dates and resolve skills removal bug

### DIFF
--- a/src/app/user-details/_components/education-modal.tsx
+++ b/src/app/user-details/_components/education-modal.tsx
@@ -94,20 +94,37 @@ export default function EducationModal({ open, onClose, initialData }: Education
       );
       toast('✅Education added successfully');
     }
-    setFormData(defaultEducation);
     onClose();
   };
 
   useEffect(() => {
-    if (initialData) {
+    if (!open) {
+      setFormData(defaultEducation);
+      setStartDate(undefined);
+      setEndDate(undefined);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (initialData && open) {
       setFormData(initialData);
       setStartDate(new Date(initialData.startYear));
       setEndDate(new Date(initialData.endYear));
     }
-  }, [initialData]);
+  }, [initialData, open]);
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) {
+          setFormData(defaultEducation);
+          setStartDate(undefined);
+          setEndDate(undefined);
+        }
+        onClose();
+      }}
+    >
       <DialogContent aria-describedby="Eduction add">
         <DialogHeader>
           <DialogTitle>Add Education</DialogTitle>

--- a/src/store/slices/skills.ts
+++ b/src/store/slices/skills.ts
@@ -16,7 +16,7 @@ export const skillsSlice = createSlice({
       state.push(action.payload);
     },
     removeSkill: (state, action: PayloadAction<string>) => {
-      state = state.filter((skill) => skill !== action.payload);
+      return state.filter((skill) => skill !== action.payload);
     },
   },
 });


### PR DESCRIPTION
1. Education Section Dates Not Resetting
- Fixed an issue where date inputs in dynamically added education entries (e.g., Education 2, 3, etc.) retained values from previous entries. Dates now reset to blank/default when adding new education sections.
2. Skills Removal Functionality
- Resolved a bug where skills were not being properly removed from the list. The skills section now correctly updates when deleting items.